### PR TITLE
chore: handle peer dependency conflicts in npm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Setup
+
+The project depends on libraries with conflicting peer dependencies. To install packages successfully, use npm's legacy peer resolution. The repository includes an `.npmrc` file so the following command works out of the box:
+
+```sh
+npm ci
+```
+
+If you're installing manually, ensure `--legacy-peer-deps` is enabled to avoid resolution errors.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:


### PR DESCRIPTION
## Summary
- document using legacy peer resolution for installs
- add `.npmrc` to enable `npm ci` without peer dependency errors

## Testing
- `npm ci`
- `npm run test:motion` *(fails: Motion v12 compatibility layer missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c489b25083328d9fab619cb071be