### PR TITLE
Simplify theme management to static Matsu theme

### DIFF
--- a/packages/zimbomate-v2/src/App.MagicalThemes.tsx
+++ b/packages/zimbomate-v2/src/App.MagicalThemes.tsx
@@ -8,52 +8,26 @@ import { Card } from './components/ui/Card'
 import { Badge } from './components/ui/Badge'
 import { Progress } from './components/ui/Progress'
 import { useTheme } from './components/ui/ThemeProvider'
-import { 
-  Sparkles, 
-  Flame, 
-  Leaf, 
-  Zap, 
-  Mountain, 
-  Moon, 
-  Star,
+import {
+  Sparkles,
+  Flame,
   Heart,
   Shield,
   Sword,
-  Wand2,
-  Crown
+  Wand2
 } from 'lucide-react'
 
-const themeDescriptions = {
-  'fantasy': 'Classic parchment and gold fantasy theme with warm, magical tones',
-  'dark': 'Sleek dark theme with golden accents for nighttime gaming',
-  'light': 'Clean light theme with subtle golden touches for bright environments',
-  'sci-fi': 'Futuristic cyber theme with neon blue and green accents',
-  'moonlit-grimoire': 'Ancient manuscript style with Uncial Antiqua headers - scholarly magic under starlit skies',
-  'dragonforge-ember': 'Bold Metamorphous lettering with crimson flames - the power of dragon-forged steel',
-  'enchanted-grove': 'Organic Kalam script with forest greens - where nature\'s handwriting meets mysticism',
-  'arcane-storm': 'Futuristic Orbitron typography with electric energy - technology meets raw magical force',
-  'ancient-sandstone': 'Classical Cinzel carved in stone - timeless mysteries of ancient civilizations'
-}
-
-const themeIcons = {
-  'fantasy': Crown,
-  'dark': Moon,
-  'light': Star,
-  'sci-fi': Zap,
-  'moonlit-grimoire': Moon,
-  'dragonforge-ember': Flame,
-  'enchanted-grove': Leaf,
-  'arcane-storm': Zap,
-  'ancient-sandstone': Mountain
-}
+const matsuThemeDescription =
+  'Ghibli-inspired parchment textures, gentle greens, and hand-painted accents define the Matsu visual identity.'
 
 function ThemeShowcaseContent() {
   const { theme } = useTheme()
+  const themeLabel = theme === 'matsu' ? 'Matsu' : theme
   const [selectedCard, setSelectedCard] = useState<string | null>(null)
   const [progress, setProgress] = useState(75)
   const [fontsLoaded, setFontsLoaded] = useState(false)
-  
-  const ThemeIcon = themeIcons[theme as keyof typeof themeIcons] || Crown
+
+  const ThemeIcon = Sparkles
   
   const handleFontsLoaded = (loaded: boolean) => {
     setFontsLoaded(loaded)
@@ -62,27 +36,9 @@ function ThemeShowcaseContent() {
     console.log('Document data-theme attribute:', document.documentElement.getAttribute('data-theme'))
   }
   
-  const getThemeSpecificClass = () => {
-    switch (theme) {
-      case 'moonlit-grimoire': return 'starfield-bg'
-      case 'dragonforge-ember': return 'forge-sparks'
-      case 'enchanted-grove': return 'bioluminescent-dots'
-      case 'arcane-storm': return 'electric-field'
-      case 'ancient-sandstone': return 'hieroglyph-pattern'
-      default: return ''
-    }
-  }
-  
-  const getThemeGlowClass = () => {
-    switch (theme) {
-      case 'moonlit-grimoire': return 'moonlit-glow'
-      case 'dragonforge-ember': return 'ember-glow'
-      case 'enchanted-grove': return 'nature-glow'
-      case 'arcane-storm': return 'lightning-glow'
-      case 'ancient-sandstone': return 'sandstone-glow'
-      default: return 'magical-glow'
-    }
-  }
+  const getThemeSpecificClass = () => 'matsu-theme-surface'
+
+  const getThemeGlowClass = () => 'magical-glow'
 
   return (
     <div className={`min-h-screen transition-all duration-500 ${getThemeSpecificClass()}`}>
@@ -102,20 +58,13 @@ function ThemeShowcaseContent() {
             >
               <ThemeIcon size={48} className="text-primary" />
             </motion.div>
-            <h1 className="text-display-lg" style={{ 
-              fontFamily: theme === 'enchanted-grove' ? 'Kalam, cursive' : 
-                         theme === 'moonlit-grimoire' ? 'Uncial Antiqua, serif' :
-                         theme === 'dragonforge-ember' ? 'Metamorphous, fantasy' :
-                         theme === 'arcane-storm' ? 'Orbitron, monospace' :
-                         theme === 'ancient-sandstone' ? 'Cinzel, serif' :
-                         'var(--font-display)'
-            }}>
+            <h1 className="text-display-lg" style={{ fontFamily: 'var(--font-display)' }}>
               ZimboMate V2: Magical Themes
             </h1>
           </div>
-          
+
           <p className="text-body-lg max-w-2xl mx-auto mb-8">
-            {themeDescriptions[theme as keyof typeof themeDescriptions]}
+            {matsuThemeDescription}
           </p>
           
           <div className="flex justify-center">
@@ -290,17 +239,10 @@ function ThemeShowcaseContent() {
                   Font Status: {fontsLoaded ? '✅ Google Fonts Loaded' : '⏳ Loading Google Fonts...'}
                 </p>
                 <p className="text-body-sm">
-                  Current Theme: <strong>{theme}</strong>
+                  Current Theme: <strong>{themeLabel}</strong>
                 </p>
                 <p className="text-body-sm">
-                  Expected Display Font: {
-                    theme === 'enchanted-grove' ? 'Kalam (handwritten)' :
-                    theme === 'moonlit-grimoire' ? 'Uncial Antiqua (medieval)' :
-                    theme === 'dragonforge-ember' ? 'Metamorphous (fantasy)' :
-                    theme === 'arcane-storm' ? 'Orbitron (futuristic)' :
-                    theme === 'ancient-sandstone' ? 'Cinzel (classical)' :
-                    'Default'
-                  }
+                  Featured Fonts: Nunito (display) & PT Sans (body)
                 </p>
                 <div className="mt-2 p-2 rounded text-body-sm" style={{ backgroundColor: 'var(--color-surface-elevated)' }}>
                   <p className="font-semibold">⚠️ For optimal font loading:</p>
@@ -345,9 +287,9 @@ function ThemeShowcaseContent() {
                 </div>
                 
                 <div>
-                  <p>Theme-specific variables:</p>
-                  <p>Grove: <span style={{ fontFamily: 'var(--font-grove)' }}>Should be Kalam handwriting</span></p>
-                  <p>Moonlit: <span style={{ fontFamily: 'var(--font-moonlit)' }}>Should be Uncial Antiqua</span></p>
+                  <p>Theme variables:</p>
+                  <p>Matsu Display: <span style={{ fontFamily: 'var(--font-display)' }}>Hand-painted headline style</span></p>
+                  <p>Matsu Body: <span style={{ fontFamily: 'var(--font-body)' }}>Readable body copy</span></p>
                 </div>
               </div>
             </div>
@@ -425,15 +367,13 @@ function ThemeShowcaseContent() {
         >
           <Card className={`p-8 text-center ${getThemeGlowClass()}`}>
             <h2 className="text-display-md mb-4">
-              Current Theme: {theme.split('-').map(word => 
-                word.charAt(0).toUpperCase() + word.slice(1)
-              ).join(' ')}
+              Current Theme: {themeLabel}
             </h2>
             <p className="text-body-lg mb-6">
-              {themeDescriptions[theme as keyof typeof themeDescriptions]}
+              {matsuThemeDescription}
             </p>
             <div className="flex justify-center gap-4">
-              <Badge variant="magical">9 Themes Available</Badge>
+              <Badge variant="magical">Matsu Theme Included</Badge>
               <Badge variant="success">Fully Responsive</Badge>
               <Badge variant="outline">Magical Effects</Badge>
             </div>

--- a/packages/zimbomate-v2/src/App.MatsuTheme.tsx
+++ b/packages/zimbomate-v2/src/App.MatsuTheme.tsx
@@ -4,20 +4,17 @@ import { Card, CardHeader, CardTitle, CardContent, Button, Badge, Progress } fro
 import { DiceRoller } from './components/game/DiceRoller'
 import { StatRoller } from './components/game/StatRoller'
 import { CharacterSheet } from './components/game/CharacterSheet'
-import { Moon, Sun, Sparkles, Dice6, User } from 'lucide-react'
+import { Sparkles, Dice6, User } from 'lucide-react'
 
-const ThemeToggle: React.FC = () => {
-  const { isDark, toggleDark } = useTheme()
-  
+const ThemeIndicator: React.FC = () => {
+  const { theme } = useTheme()
+
   return (
-    <Button
-      variant="outline"
-      size="icon"
-      onClick={toggleDark}
-      className="fixed top-4 right-4 z-50"
-    >
-      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-    </Button>
+    <div className="fixed top-4 right-4 z-50">
+      <Badge variant="magical" aria-label={`Active theme: ${theme}`}>
+        {theme === 'matsu' ? 'Matsu Theme' : theme}
+      </Badge>
+    </div>
   )
 }
 
@@ -26,7 +23,7 @@ const MatsuShowcase: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <ThemeToggle />
+      <ThemeIndicator />
       
       <div className="container mx-auto px-4 py-8 max-w-6xl">
         {/* Header */}

--- a/packages/zimbomate-v2/src/App.ThemeTest.tsx
+++ b/packages/zimbomate-v2/src/App.ThemeTest.tsx
@@ -4,30 +4,17 @@ import { ThemeProvider, useTheme } from './components/ui/ThemeProvider'
 import { ThemeToggle } from './components/ui/ThemeToggle'
 import { Button } from './components/ui/Button'
 import { Card, CardContent } from './components/ui'
-import { Sparkles, Palette, Moon, Sun, Rocket } from 'lucide-react'
+import { Sparkles, Palette } from 'lucide-react'
 
 const ThemeShowcase: React.FC = () => {
   const { theme, animations, sounds, toggleAnimations, toggleSounds } = useTheme()
 
-  const getThemeIcon = () => {
-    switch (theme) {
-      case 'fantasy': return <Sparkles className="w-8 h-8" />
-      case 'dark': return <Moon className="w-8 h-8" />
-      case 'light': return <Sun className="w-8 h-8" />
-      case 'sci-fi': return <Rocket className="w-8 h-8" />
-      default: return <Palette className="w-8 h-8" />
-    }
-  }
+  const themeDisplayName = theme === 'matsu' ? 'Matsu' : theme
 
-  const getThemeDescription = () => {
-    switch (theme) {
-      case 'fantasy': return 'Magical parchment with golden accents and mystical purple highlights'
-      case 'dark': return 'Dark mode with golden highlights and purple magical elements'
-      case 'light': return 'Clean light theme with subtle golden touches'
-      case 'sci-fi': return 'Futuristic cyber theme with neon blue and green accents'
-      default: return 'Unknown theme'
-    }
-  }
+  const getThemeIcon = () => <Sparkles className="w-8 h-8" />
+
+  const getThemeDescription = () =>
+    'Ghibli-inspired visuals with warm parchment textures and magical accents.'
 
   return (
     <div 
@@ -91,7 +78,7 @@ const ThemeShowcase: React.FC = () => {
                       className="text-sm"
                       style={{ color: 'var(--color-text-secondary)' }}
                     >
-                      Current: {theme.charAt(0).toUpperCase() + theme.slice(1)}
+                      Current: {themeDisplayName}
                     </p>
                   </div>
                 </div>

--- a/packages/zimbomate-v2/src/components/3d/Enhanced3DParticles.tsx
+++ b/packages/zimbomate-v2/src/components/3d/Enhanced3DParticles.tsx
@@ -28,22 +28,24 @@ export interface Enhanced3DParticlesProps {
   position?: [number, number, number]
   type: 'success' | 'partial' | 'failure' | 'collision' | 'magical' | 'trail'
   intensity?: number
+  theme?: 'matsu'
+  duration?: number
+  onComplete?: () => void
 }
 
 // PERFORMANCE: 3D Particles completely removed
 export const Enhanced3DParticles: React.FC<Enhanced3DParticlesProps> = () => {
   return null
-  theme?: 'fantasy' | 'sci-fi' | 'dark' | 'light'
-  duration?: number
-  onComplete?: () => void
 }
 
 // Particle configurations for different effects
 const getParticleConfig = (
-  type: string, 
-  theme: string, 
+  type: string,
+  theme: string,
   intensity = 1
 ): ParticleConfig => {
+  const resolvedTheme = theme === 'matsu' ? 'fantasy' : theme
+
   const configs = {
     success: {
       fantasy: {
@@ -324,7 +326,7 @@ const getParticleConfig = (
   }
   
   const themeConfigs = configs[type as keyof typeof configs]
-  return themeConfigs[theme as keyof typeof themeConfigs] || themeConfigs.fantasy
+  return themeConfigs[resolvedTheme as keyof typeof themeConfigs] || themeConfigs.fantasy
 }
 
 // Individual particle class

--- a/packages/zimbomate-v2/src/components/__tests__/integration/AppIntegration.test.tsx
+++ b/packages/zimbomate-v2/src/components/__tests__/integration/AppIntegration.test.tsx
@@ -178,25 +178,14 @@ describe('App Integration Tests', () => {
   })
 
   describe('Theme Integration', () => {
-    it('applies theme consistently across components', async () => {
+    it('displays the Matsu theme indicator across components', async () => {
       const { user } = renderWithProviders(<App />)
 
-      // Toggle theme
-      const themeToggle = screen.getByRole('button', { name: /toggle theme/i })
-      await user.click(themeToggle)
+      const themeIndicator = await screen.findByRole('status', { name: /active theme/i })
+      expect(themeIndicator).toHaveTextContent(/matsu/i)
 
-      // Check that theme is applied to different components
-      await waitFor(() => {
-        const characterSheet = screen.getByTestId('character-sheet')
-        expect(characterSheet).toHaveClass('dark')
-      })
-
-      // Switch tabs and verify theme persistence
       await user.click(screen.getByRole('tab', { name: /dice/i }))
-      await waitFor(() => {
-        const diceRoller = screen.getByTestId('dice-roller')
-        expect(diceRoller).toHaveClass('dark')
-      })
+      expect(screen.getByRole('status', { name: /active theme/i })).toBeInTheDocument()
     })
   })
 

--- a/packages/zimbomate-v2/src/components/ui/ThemeProvider.tsx
+++ b/packages/zimbomate-v2/src/components/ui/ThemeProvider.tsx
@@ -1,9 +1,8 @@
-import React, { createContext, useContext, useEffect } from 'react'
+import React, { createContext, useContext } from 'react'
 import { useThemeStore } from '../../stores/themeStore'
 
 interface ThemeContextType {
-  isDark: boolean
-  toggleDark: () => void
+  readonly theme: 'matsu'
   animations: boolean
   sounds: boolean
   toggleAnimations: () => void
@@ -22,30 +21,20 @@ export function useTheme() {
 
 interface ThemeProviderProps {
   children: React.ReactNode
+  defaultTheme?: 'matsu'
 }
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  const { 
-    isDark, 
-    toggleDark, 
-    animations, 
-    sounds, 
-    toggleAnimations, 
-    toggleSounds 
+  const {
+    theme,
+    animations,
+    sounds,
+    toggleAnimations,
+    toggleSounds
   } = useThemeStore()
 
-  useEffect(() => {
-    // Apply dark mode class on mount and changes
-    if (isDark) {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  }, [isDark])
-
   const value = {
-    isDark,
-    toggleDark,
+    theme,
     animations,
     sounds,
     toggleAnimations,

--- a/packages/zimbomate-v2/src/components/ui/ThemeToggle.tsx
+++ b/packages/zimbomate-v2/src/components/ui/ThemeToggle.tsx
@@ -1,73 +1,19 @@
 import React from 'react'
-import * as Select from '@radix-ui/react-select'
 import { useTheme } from './ThemeProvider'
-import { Palette, ChevronDown, Check } from 'lucide-react'
-import { Theme } from '../../types/enums'
-
-const themes = [
-  { value: 'fantasy' as Theme, label: 'Fantasy', icon: '🏰' },
-  { value: 'dark' as Theme, label: 'Dark', icon: '🌑' },
-  { value: 'light' as Theme, label: 'Light', icon: '☀️' },
-  { value: 'sci-fi' as Theme, label: 'Sci-Fi', icon: '🚀' },
-  { value: 'moonlit-grimoire' as Theme, label: 'Moonlit Grimoire', icon: '🌙' },
-  { value: 'dragonforge-ember' as Theme, label: 'Dragonforge Ember', icon: '🔥' },
-  { value: 'enchanted-grove' as Theme, label: 'Enchanted Grove', icon: '🌿' },
-  { value: 'arcane-storm' as Theme, label: 'Arcane Storm', icon: '⚡' },
-  { value: 'ancient-sandstone' as Theme, label: 'Ancient Sandstone', icon: '🏺' }
-] as const
+import { Palette } from 'lucide-react'
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+  const { theme } = useTheme()
+  const label = theme === 'matsu' ? 'Matsu Theme Active' : theme
 
   return (
-    <Select.Root value={theme} onValueChange={(value) => setTheme(value as Theme)}>
-      <Select.Trigger
-        className="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm hover:opacity-90 focus:outline-none"
-        aria-label="Select theme"
-      >
-        <Palette size={16} />
-        <Select.Value placeholder="Theme" />
-        <Select.Icon>
-          <ChevronDown size={14} />
-        </Select.Icon>
-      </Select.Trigger>
-
-      <Select.Portal>
-        <Select.Content 
-          className="z-[1000] overflow-hidden rounded-lg border shadow-lg min-w-[140px]"
-          position="popper"
-          sideOffset={6}
-          style={{ 
-            backgroundColor: 'var(--color-surface)', 
-            borderColor: 'var(--color-border)' 
-          }}
-        >
-          <Select.Viewport className="p-1">
-            {themes.map((themeOption) => (
-              <Select.Item
-                key={themeOption.value}
-                value={themeOption.value}
-                className="flex items-center gap-2 px-3 py-2 text-sm rounded-md cursor-pointer outline-none relative transition-colors"
-                style={{
-                  color: 'var(--color-text-primary)'
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor = 'var(--color-surface-elevated)'
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor = 'transparent'
-                }}
-              >
-                <span>{themeOption.icon}</span>
-                <Select.ItemText>{themeOption.label}</Select.ItemText>
-                <Select.ItemIndicator className="absolute right-2">
-                  <Check size={14} />
-                </Select.ItemIndicator>
-              </Select.Item>
-            ))}
-          </Select.Viewport>
-        </Select.Content>
-      </Select.Portal>
-    </Select.Root>
+    <div
+      className="inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm bg-card text-card-foreground"
+      role="status"
+      aria-label={`Active theme: ${label}`}
+    >
+      <Palette size={16} />
+      <span className="font-medium">{label}</span>
+    </div>
   )
 }

--- a/packages/zimbomate-v2/src/hooks/useAnimations.ts
+++ b/packages/zimbomate-v2/src/hooks/useAnimations.ts
@@ -88,7 +88,7 @@ export interface UseAnimationsReturn {
  * Hook for managing animations and visual effects
  */
 export function useAnimations(): UseAnimationsReturn {
-  const { currentTheme } = useThemeStore()
+  const { theme } = useThemeStore()
   
   const [preferences, setPreferences] = useState<AnimationPreferences>(() => {
     // Check for user's motion preferences
@@ -137,25 +137,17 @@ export function useAnimations(): UseAnimationsReturn {
       error: 'var(--color-error)',
     }
 
-    // Override with theme-specific colors if available
-    if (currentTheme === 'fantasy') {
+    if (theme === 'matsu') {
       return {
         ...colors,
-        primary: 'var(--color-gold)',
-        secondary: 'var(--color-parchment)',
-        accent: 'var(--color-mystical-purple)',
-      }
-    } else if (currentTheme === 'sci-fi') {
-      return {
-        ...colors,
-        primary: 'var(--color-cyber-blue)',
-        secondary: 'var(--color-neon-green)',
-        accent: 'var(--color-electric-purple)',
+        primary: 'var(--matsu-primary, var(--color-primary))',
+        secondary: 'var(--matsu-secondary, var(--color-secondary))',
+        accent: 'var(--matsu-accent, var(--color-accent))',
       }
     }
 
     return colors
-  }, [currentTheme])
+  }, [theme])
 
   // Particle effects
   const triggerParticles = useCallback((

--- a/packages/zimbomate-v2/src/stores/themeStore.ts
+++ b/packages/zimbomate-v2/src/stores/themeStore.ts
@@ -2,10 +2,9 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 interface ThemeState {
-  isDark: boolean
+  readonly theme: 'matsu'
   animations: boolean
   sounds: boolean
-  toggleDark: () => void
   toggleAnimations: () => void
   toggleSounds: () => void
 }
@@ -13,34 +12,14 @@ interface ThemeState {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set) => ({
-      isDark: false,
+      theme: 'matsu',
       animations: true,
       sounds: true,
-      toggleDark: () => {
-        set((state) => {
-          const newDark = !state.isDark
-          // Update the document class for dark mode
-          if (newDark) {
-            document.documentElement.classList.add('dark')
-          } else {
-            document.documentElement.classList.remove('dark')
-          }
-          return { isDark: newDark }
-        })
-      },
       toggleAnimations: () => set((state) => ({ animations: !state.animations })),
       toggleSounds: () => set((state) => ({ sounds: !state.sounds })),
     }),
     {
       name: 'zimbomate-matsu-theme-storage',
-      onRehydrateStorage: () => (state) => {
-        // Apply dark mode on hydration
-        if (state?.isDark) {
-          document.documentElement.classList.add('dark')
-        } else {
-          document.documentElement.classList.remove('dark')
-        }
-      },
     }
   )
 )

--- a/packages/zimbomate-v2/src/types/enums.ts
+++ b/packages/zimbomate-v2/src/types/enums.ts
@@ -1,7 +1,7 @@
 export type ColorVariant = 'primary' | 'secondary' | 'accent' | 'muted' | 'destructive'
 
-// Simplified theme system - only light/dark variants of Matsu theme
-export type Theme = 'light' | 'dark'
+// Simplified theme system - single Matsu theme
+export type Theme = 'matsu'
 
 export type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link' | 'magical'
 

--- a/packages/zimbomate-v2/src/utils/testing.tsx
+++ b/packages/zimbomate-v2/src/utils/testing.tsx
@@ -10,7 +10,7 @@ import * as Tooltip from '@radix-ui/react-tooltip'
 // Test utilities for ZimboMate V2
 interface TestWrapperProps {
   children: React.ReactNode
-  theme?: 'fantasy' | 'dark' | 'light'
+  theme?: 'matsu'
   withErrorBoundary?: boolean
   withQueryClient?: boolean
   withTooltips?: boolean
@@ -19,7 +19,7 @@ interface TestWrapperProps {
 // Custom test wrapper with all providers
 const TestWrapper: React.FC<TestWrapperProps> = ({
   children,
-  theme = 'fantasy',
+  theme = 'matsu',
   withErrorBoundary = true,
   withQueryClient = true,
   withTooltips = true
@@ -74,7 +74,7 @@ const TestWrapper: React.FC<TestWrapperProps> = ({
 
 // Enhanced render function with custom wrapper
 interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
-  theme?: 'fantasy' | 'dark' | 'light'
+  theme?: 'matsu'
   withErrorBoundary?: boolean
   withQueryClient?: boolean
   withTooltips?: boolean
@@ -85,7 +85,7 @@ export const renderWithProviders = (
   options: CustomRenderOptions = {}
 ) => {
   const {
-    theme = 'fantasy',
+    theme = 'matsu',
     withErrorBoundary = true,
     withQueryClient = true,
     withTooltips = true,


### PR DESCRIPTION
## Summary
- refactor the theme store and provider to expose only animation and sound toggles alongside the static `matsu` theme
- update UI demos, hooks, and tests to reference the new theme shape and display a passive theme indicator
- align shared utilities and 3D particle helpers with the single-theme setup and refreshed typings

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68d1e8d63da08332ac513e206a6c2c2e