### PR TITLE
Refactor toaster theme handling

### DIFF
--- a/packages/zimbomate-v2/src/components/ui/__tests__/sonner.test.tsx
+++ b/packages/zimbomate-v2/src/components/ui/__tests__/sonner.test.tsx
@@ -1,0 +1,29 @@
+import { render, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { describe, expect, it } from 'vitest'
+
+import { Toaster } from '../sonner'
+
+describe('Toaster', () => {
+  it('applies Matsu theme styles to the Sonner container', async () => {
+    const { unmount } = render(<Toaster />)
+
+    toast('testing matsu colors')
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-sonner-toaster]')
+      ).toBeInTheDocument()
+    })
+
+    const toaster = document.querySelector('[data-sonner-toaster]') as HTMLElement
+
+    expect(toaster).toHaveAttribute('data-sonner-theme', 'matsu')
+    expect(toaster).toHaveStyle('--normal-bg: var(--popover)')
+    expect(toaster).toHaveStyle('--normal-text: var(--popover-foreground)')
+    expect(toaster).toHaveStyle('--normal-border: var(--border)')
+
+    toast.dismiss()
+    unmount()
+  })
+})

--- a/packages/zimbomate-v2/src/components/ui/sonner.tsx
+++ b/packages/zimbomate-v2/src/components/ui/sonner.tsx
@@ -1,20 +1,27 @@
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import type { CSSProperties } from 'react'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
 
-const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+type MatsuToasterProps = Omit<ToasterProps, 'theme'> & {
+  readonly theme?: 'light' | 'matsu'
+}
+
+const matsuToastStyles: CSSProperties = {
+  '--normal-bg': 'var(--popover)',
+  '--normal-text': 'var(--popover-foreground)',
+  '--normal-border': 'var(--border)',
+}
+
+const Toaster = ({ theme = 'matsu', style, ...props }: MatsuToasterProps) => {
+  const mergedStyles: CSSProperties = {
+    ...matsuToastStyles,
+    ...style,
+  }
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
-      style={
-        {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-        } as React.CSSProperties
-      }
+      style={mergedStyles}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- replace the Sonner Toaster's dependency on `next-themes` with a literal `'matsu'`/`'light'` theme while keeping the CSS variable styling
- merge custom inline styles with the default Matsu colors so consumers can extend the toast appearance
- add a focused test that renders a toast and asserts the Sonner container keeps the Matsu color variables applied

## Testing
- npm run test:run -- src/components/ui/__tests__/sonner.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1f6a5515c8332be5a8310456c84fa